### PR TITLE
Refactor .gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,9 +17,17 @@
 *.ear
 *.tar.gz
 *.rar
+*.zip
+
+# Only include zip files inside exporter projects
+!**/**Exporter/*.zip
 
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
 
 # MacOS system files
 .DS_Store
+
+# Excluding .meta and target directories
+**/.meta
+**/target


### PR DESCRIPTION
## Purpose
Refactoring .gitignore file to:

1. Exclude .meta, target directories
2. Exclude all zip files
3. Include zip files only in exporter projects